### PR TITLE
Make bid params apply to individual slots only

### DIFF
--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -29,11 +29,12 @@ export const spec = {
 
     const slots = validBidRequests.map(bid => ({
       slotname: bidToSlotName(bid),
-      parameters: mergeTargets(commonParams, bid.params.data)
+      parameters: cleanTargets(bid.params.data)
     }));
 
     const payload = {
-      slots: slots
+      slots: slots,
+      parameters: commonParams
     }
 
     const account = getAccount(validBidRequests);
@@ -113,24 +114,24 @@ function adResponse(bid, ad) {
   return bidResponse;
 }
 
-function mergeTargets(targets, target) {
-  const targetsCopy = { ...targets };
+function cleanTargets(target) {
+  const targets = {};
   if (target) {
     Object.keys(target).forEach(function (key) {
       const val = target[key];
       const dirtyValues = Array.isArray(val) ? val : [val];
       const values = dirtyValues.filter(v => v === 0 || v);
       if (values.length > 0) {
-        if (targetsCopy[key]) {
-          const distinctValues = values.filter(v => targetsCopy[key].indexOf(v) < 0);
-          targetsCopy[key].push.apply(targetsCopy[key], distinctValues);
+        if (targets[key]) {
+          const distinctValues = values.filter(v => targets[key].indexOf(v) < 0);
+          targets[key].push.apply(targets[key], distinctValues);
         } else {
-          targetsCopy[key] = values;
+          targets[key] = values;
         }
       }
     });
   }
-  return targetsCopy;
+  return targets;
 }
 
 function bidToSlotName(bid) {

--- a/test/spec/modules/adheseBidAdapter_spec.js
+++ b/test/spec/modules/adheseBidAdapter_spec.js
@@ -74,31 +74,33 @@ describe('AdheseAdapter', function () {
     it('should include requested slots', function () {
       let req = spec.buildRequests([ minimalBid() ], bidderRequest);
 
-      expect(JSON.parse(req.data).slots).to.deep.include({ 'slotname': '_main_page_-leaderboard' });
+      expect(JSON.parse(req.data).slots[0].slotname).to.equal('_main_page_-leaderboard');
     });
 
     it('should include all extra bid params', function () {
       let req = spec.buildRequests([ bidWithParams({ 'ag': '25' }) ], bidderRequest);
 
-      expect(JSON.parse(req.data).parameters).to.deep.include({ 'ag': [ '25' ] });
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'ag': [ '25' ] });
     });
 
-    it('should include duplicate bid params once', function () {
+    it('should assign bid params per slot', function () {
       let req = spec.buildRequests([ bidWithParams({ 'ag': '25' }), bidWithParams({ 'ag': '25', 'ci': 'gent' }) ], bidderRequest);
 
-      expect(JSON.parse(req.data).parameters).to.deep.include({'ag': ['25']}).and.to.deep.include({ 'ci': [ 'gent' ] });
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'ag': [ '25' ] }).and.not.to.deep.include({ 'ci': [ 'gent' ] });
+      expect(JSON.parse(req.data).slots[1].parameters).to.deep.include({ 'ag': [ '25' ] }).and.to.deep.include({ 'ci': [ 'gent' ] });
     });
 
     it('should split multiple target values', function () {
       let req = spec.buildRequests([ bidWithParams({ 'ci': 'london' }), bidWithParams({ 'ci': 'gent' }) ], bidderRequest);
 
-      expect(JSON.parse(req.data).parameters).to.deep.include({ 'ci': [ 'london', 'gent' ] });
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'ci': [ 'london' ] });
+      expect(JSON.parse(req.data).slots[1].parameters).to.deep.include({ 'ci': [ 'gent' ] });
     });
 
     it('should filter out empty params', function () {
       let req = spec.buildRequests([ bidWithParams({ 'aa': [], 'bb': null, 'cc': '', 'dd': [ '', '' ], 'ee': [ 0, 1, null ], 'ff': 0, 'gg': [ 'x', 'y', '' ] }) ], bidderRequest);
 
-      let params = JSON.parse(req.data).parameters;
+      let params = JSON.parse(req.data).slots[0].parameters;
       expect(params).to.not.have.any.keys('aa', 'bb', 'cc', 'dd');
       expect(params).to.deep.include({ 'ee': [ 0, 1 ], 'ff': [ 0 ], 'gg': [ 'x', 'y' ] });
     });
@@ -106,19 +108,19 @@ describe('AdheseAdapter', function () {
     it('should include gdpr consent param', function () {
       let req = spec.buildRequests([ minimalBid() ], bidderRequest);
 
-      expect(JSON.parse(req.data).parameters).to.deep.include({ 'xt': [ 'CONSENT_STRING' ] });
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'xt': [ 'CONSENT_STRING' ] });
     });
 
     it('should include referer param in base64url format', function () {
       let req = spec.buildRequests([ minimalBid() ], bidderRequest);
 
-      expect(JSON.parse(req.data).parameters).to.deep.include({ 'xf': [ 'aHR0cDovL3ByZWJpZC5vcmcvZGV2LWRvY3Mvc3ViamVjdHM_X2Q9MQ' ] });
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'xf': [ 'aHR0cDovL3ByZWJpZC5vcmcvZGV2LWRvY3Mvc3ViamVjdHM_X2Q9MQ' ] });
     });
 
     it('should include id5 id as /x5 param', function () {
       let req = spec.buildRequests([ bidWithParams({}, { 'id5id': { 'uid': 'ID5-1234567890' } }) ], bidderRequest);
 
-      expect(JSON.parse(req.data).parameters).to.deep.include({ 'x5': [ 'ID5-1234567890' ] });
+      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'x5': [ 'ID5-1234567890' ] });
     });
 
     it('should include bids', function () {

--- a/test/spec/modules/adheseBidAdapter_spec.js
+++ b/test/spec/modules/adheseBidAdapter_spec.js
@@ -108,19 +108,19 @@ describe('AdheseAdapter', function () {
     it('should include gdpr consent param', function () {
       let req = spec.buildRequests([ minimalBid() ], bidderRequest);
 
-      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'xt': [ 'CONSENT_STRING' ] });
+      expect(JSON.parse(req.data).parameters).to.deep.include({ 'xt': [ 'CONSENT_STRING' ] });
     });
 
     it('should include referer param in base64url format', function () {
       let req = spec.buildRequests([ minimalBid() ], bidderRequest);
 
-      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'xf': [ 'aHR0cDovL3ByZWJpZC5vcmcvZGV2LWRvY3Mvc3ViamVjdHM_X2Q9MQ' ] });
+      expect(JSON.parse(req.data).parameters).to.deep.include({ 'xf': [ 'aHR0cDovL3ByZWJpZC5vcmcvZGV2LWRvY3Mvc3ViamVjdHM_X2Q9MQ' ] });
     });
 
     it('should include id5 id as /x5 param', function () {
       let req = spec.buildRequests([ bidWithParams({}, { 'id5id': { 'uid': 'ID5-1234567890' } }) ], bidderRequest);
 
-      expect(JSON.parse(req.data).slots[0].parameters).to.deep.include({ 'x5': [ 'ID5-1234567890' ] });
+      expect(JSON.parse(req.data).parameters).to.deep.include({ 'x5': [ 'ID5-1234567890' ] });
     });
 
     it('should include bids', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
